### PR TITLE
Add minimum php version to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "psr-4": {
             "Lwwcas\\Help\\": "src/"
         },
-        "files": {
-             "Lwwcas\\Help\\": "src/entities/helpers.php"
-        }
+        "files": [
+             "src/entities/helpers.php"
+        ]
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "help"
     ],
     "require": {
-        "mcamara/laravel-localization": "^1.3"
+        "mcamara/laravel-localization": "^1.3",
+        "php": "^7.0"
     },
     "homepage": "https://github.com/lwwcas/help",
     "type": "library",


### PR DESCRIPTION
For return types you must specify a minimum PHP version of 7.0