### PR TITLE
Add Laravel as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "mcamara/laravel-localization": "^1.3",
-        "php": "^7.0"
+        "php": "^7.0",
+        "laravel/laravel": ">=5.4.*"
     },
     "homepage": "https://github.com/lwwcas/help",
     "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "psr-4": {
             "Lwwcas\\Help\\": "src/"
         },
-        "files": {
-             "Lwwcas\\Help\\": "src/entities/helpers.php"
-        }
+        "files": [
+             "src/entities/helpers.php"
+        ]
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "help"
     ],
     "require": {
-        "mcamara/laravel-localization": "^1.3"
+        "mcamara/laravel-localization": "^1.3",
+        "php": "^7.0"
     },
     "homepage": "https://github.com/lwwcas/help",
     "type": "library",


### PR DESCRIPTION
Since you're using Laravel helpers for example `str_after` you must specify that it is required.